### PR TITLE
Fix shared tasks read/write race when editing tasks

### DIFF
--- a/src/core/services/TaskService.ts
+++ b/src/core/services/TaskService.ts
@@ -48,6 +48,7 @@ export class TaskService implements vscode.Disposable {
     private readonly _reminderService: ReminderService;
     private readonly _sharedTasksChangedSubscription: vscode.Disposable;
     private _commentScanQueue: Promise<void> = Promise.resolve();
+    private _taskMutationQueue: Promise<void> = Promise.resolve();
     private _isCommentScanSuspended = false;
 
     constructor(private readonly _storageManager: StorageManager) {
@@ -92,6 +93,16 @@ export class TaskService implements vscode.Disposable {
     }
 
     public async getTasks(): Promise<TodoItem[]> {
+        return this._runExclusiveTaskOperation(() => this._loadTasks());
+    }
+
+    private _runExclusiveTaskOperation<T>(operation: () => Promise<T>): Promise<T> {
+        const next = this._taskMutationQueue.then(operation, operation);
+        this._taskMutationQueue = next.then(() => undefined, () => undefined);
+        return next;
+    }
+
+    private async _loadTasks(): Promise<TodoItem[]> {
         try {
             const tasks = await this._storageManager.getTasks();
             let changed = false;
@@ -192,29 +203,33 @@ export class TaskService implements vscode.Disposable {
     }
 
     public async addTask(taskData: TaskInput): Promise<TodoItem[]> {
-        try {
-            const tasks = await this.getTasks();
-            const newTask = this._buildTask(taskData, tasks);
-            tasks.push(newTask);
-            await this._saveAndNotify(tasks);
-            return tasks;
-        } catch (error) {
-            Logger.error('Error adding task', error);
-            throw error;
-        }
+        return this._runExclusiveTaskOperation(async () => {
+            try {
+                const tasks = await this._loadTasks();
+                const newTask = this._buildTask(taskData, tasks);
+                tasks.push(newTask);
+                await this._saveAndNotify(tasks);
+                return tasks;
+            } catch (error) {
+                Logger.error('Error adding task', error);
+                throw error;
+            }
+        });
     }
 
     public async createTask(taskData: TaskInput): Promise<TodoItem> {
-        try {
-            const tasks = await this.getTasks();
-            const newTask = this._buildTask(taskData, tasks);
-            tasks.push(newTask);
-            await this._saveAndNotify(tasks);
-            return newTask;
-        } catch (error) {
-            Logger.error('Error creating task', error);
-            throw error;
-        }
+        return this._runExclusiveTaskOperation(async () => {
+            try {
+                const tasks = await this._loadTasks();
+                const newTask = this._buildTask(taskData, tasks);
+                tasks.push(newTask);
+                await this._saveAndNotify(tasks);
+                return newTask;
+            } catch (error) {
+                Logger.error('Error creating task', error);
+                throw error;
+            }
+        });
     }
 
     public async updateOrder(id: string, newOrder: number): Promise<TodoItem[]> {
@@ -224,20 +239,22 @@ export class TaskService implements vscode.Disposable {
     }
 
     public async updateOrders(orders: { id: string; order: number }[]): Promise<TodoItem[]> {
-        try {
-            const tasks = await this.getTasks();
-            orders.forEach(o => {
-                const task = tasks.find(t => t.id === o.id);
-                if (task) {
-                    task.order = o.order;
-                }
-            });
-            await this._saveAndNotify(tasks);
-            return tasks;
-        } catch (error) {
-            Logger.error('Error updating orders', error);
-            throw error;
-        }
+        return this._runExclusiveTaskOperation(async () => {
+            try {
+                const tasks = await this._loadTasks();
+                orders.forEach(o => {
+                    const task = tasks.find(t => t.id === o.id);
+                    if (task) {
+                        task.order = o.order;
+                    }
+                });
+                await this._saveAndNotify(tasks);
+                return tasks;
+            } catch (error) {
+                Logger.error('Error updating orders', error);
+                throw error;
+            }
+        });
     }
 
     public async updateStatus(id: string, status: Status): Promise<TodoItem[]> {
@@ -288,15 +305,17 @@ export class TaskService implements vscode.Disposable {
     }
 
     public async deleteTask(id: string): Promise<TodoItem[]> {
-        try {
-            let tasks = await this.getTasks();
-            tasks = tasks.filter(t => t.id !== id);
-            await this._saveAndNotify(tasks);
-            return tasks;
-        } catch (error) {
-            Logger.error('Error deleting task', error);
-            throw error;
-        }
+        return this._runExclusiveTaskOperation(async () => {
+            try {
+                let tasks = await this._loadTasks();
+                tasks = tasks.filter(t => t.id !== id);
+                await this._saveAndNotify(tasks);
+                return tasks;
+            } catch (error) {
+                Logger.error('Error deleting task', error);
+                throw error;
+            }
+        });
     }
 
     public async clearAllTasks(): Promise<void> {
@@ -394,18 +413,20 @@ export class TaskService implements vscode.Disposable {
     }
 
     private async _updateTask(id: string, updater: (task: TodoItem) => void): Promise<TodoItem[]> {
-        try {
-            const tasks = await this.getTasks();
-            const task = tasks.find(t => t.id === id);
-            if (task) {
-                updater(task);
-                await this._saveAndNotify(tasks);
+        return this._runExclusiveTaskOperation(async () => {
+            try {
+                const tasks = await this._loadTasks();
+                const task = tasks.find(t => t.id === id);
+                if (task) {
+                    updater(task);
+                    await this._saveAndNotify(tasks);
+                }
+                return tasks;
+            } catch (error) {
+                Logger.error('Error updating task', error);
+                throw error;
             }
-            return tasks;
-        } catch (error) {
-            Logger.error('Error updating task', error);
-            throw error;
-        }
+        });
     }
 
     private _buildTask(taskData: TaskInput, tasks: TodoItem[]): TodoItem {
@@ -425,9 +446,11 @@ export class TaskService implements vscode.Disposable {
     }
 
     public async saveTasks(tasks: TodoItem[]): Promise<void> {
-        await this._saveTasks(tasks);
-        this._onTasksChanged.fire(tasks);
-        this._reminderService.scheduleNextReminder();
+        return this._runExclusiveTaskOperation(async () => {
+            await this._saveTasks(tasks);
+            this._onTasksChanged.fire(tasks);
+            this._reminderService.scheduleNextReminder();
+        });
     }
 
     private async _saveTasks(tasks: TodoItem[]): Promise<void> {

--- a/src/core/storage/StorageManager.ts
+++ b/src/core/storage/StorageManager.ts
@@ -21,6 +21,8 @@ export class StorageManager implements vscode.Disposable {
     private static readonly STORAGE_KEY = 'todo4vcode-tasks';
     private static readonly SETTINGS_KEY = 'todo4vcode-settings';
     private static readonly WATCHER_IGNORE_WINDOW_MS = 1500;
+    private static readonly SHARED_TASKS_READ_MAX_ATTEMPTS = 5;
+    private static readonly SHARED_TASKS_READ_RETRY_BASE_MS = 25;
 
     private readonly _onSharedTasksChanged = new vscode.EventEmitter<SharedTasksChangedEvent>();
     public readonly onSharedTasksChanged = this._onSharedTasksChanged.event;
@@ -182,38 +184,57 @@ export class StorageManager implements vscode.Disposable {
     }
 
     private async _readSharedTasksFromUri(sharedUri: vscode.Uri, silent = false): Promise<TodoItem[]> {
-        try {
-            const fileData = await vscode.workspace.fs.readFile(sharedUri);
-            const parsedData = JSON.parse(Buffer.from(fileData).toString('utf8')) as unknown;
-            const tasks = this._extractTasksFromSharedFile(parsedData);
+        for (let attempt = 1; attempt <= StorageManager.SHARED_TASKS_READ_MAX_ATTEMPTS; attempt++) {
+            try {
+                const fileData = await vscode.workspace.fs.readFile(sharedUri);
+                if (!fileData || fileData.byteLength === 0) {
+                    throw new SyntaxError('Shared tasks file is empty');
+                }
 
-            this._lastValidSharedTasks = tasks;
-            this._hasLastValidSharedTasks = true;
-            this._invalidSharedFileWarningByUri.delete(sharedUri.toString());
-            return tasks;
-        } catch (error) {
-            if (this._isFileNotFoundError(error)) {
-                this._lastValidSharedTasks = [];
+                const parsedData = JSON.parse(Buffer.from(fileData).toString('utf8')) as unknown;
+                const tasks = this._extractTasksFromSharedFile(parsedData);
+
+                this._lastValidSharedTasks = tasks;
                 this._hasLastValidSharedTasks = true;
+                this._invalidSharedFileWarningByUri.delete(sharedUri.toString());
+                return tasks;
+            } catch (error) {
+                if (this._isFileNotFoundError(error)) {
+                    this._lastValidSharedTasks = [];
+                    this._hasLastValidSharedTasks = true;
+                    return [];
+                }
+
+                const isRetryableParseError =
+                    error instanceof SyntaxError ||
+                    (error instanceof Error && /JSON|Unexpected end/i.test(error.message));
+
+                if (isRetryableParseError && attempt < StorageManager.SHARED_TASKS_READ_MAX_ATTEMPTS) {
+                    await new Promise((resolve) =>
+                        setTimeout(resolve, StorageManager.SHARED_TASKS_READ_RETRY_BASE_MS * attempt)
+                    );
+                    continue;
+                }
+
+                Logger.error('Failed to read shared tasks file', error, sharedUri.fsPath);
+
+                const sharedUriKey = sharedUri.toString();
+                if (!silent && !this._invalidSharedFileWarningByUri.has(sharedUriKey)) {
+                    vscode.window.showErrorMessage(
+                        'Shared tasks file is invalid JSON. Keeping last valid tasks until it is fixed.'
+                    );
+                    this._invalidSharedFileWarningByUri.add(sharedUriKey);
+                }
+
+                if (this._hasLastValidSharedTasks) {
+                    return [...this._lastValidSharedTasks];
+                }
+
                 return [];
             }
-
-            Logger.error('Failed to read shared tasks file', error, sharedUri.fsPath);
-
-            const sharedUriKey = sharedUri.toString();
-            if (!silent && !this._invalidSharedFileWarningByUri.has(sharedUriKey)) {
-                vscode.window.showErrorMessage(
-                    'Shared tasks file is invalid JSON. Keeping last valid tasks until it is fixed.'
-                );
-                this._invalidSharedFileWarningByUri.add(sharedUriKey);
-            }
-
-            if (this._hasLastValidSharedTasks) {
-                return [...this._lastValidSharedTasks];
-            }
-
-            return [];
         }
+
+        return [];
     }
 
     private _extractTasksFromSharedFile(data: unknown): TodoItem[] {


### PR DESCRIPTION
## Summary

- Serialize task mutations in `TaskService` through a single queue so overlapping read-modify-write cycles do not interleave on the shared JSON file.
- Retry shared-file JSON parsing briefly when a transient parse error occurs (e.g. truncated read while another write is finishing).

Fixes #12

## Problem

With `todo4vcode.sharedTasks.enabled`, editing tasks could fail with:

> Shared tasks file is invalid JSON. Keeping last valid tasks until it is fixed.

Logs showed `SyntaxError: Unexpected end of JSON input` even though the on-disk JSON was valid. Multiple concurrent reads/writes on `.todo4vcode/shared-tasks.json` caused partial reads during non-atomic writes (task modal save posts three updates in quick succession; status bar/reminder refresh adds more reads).

## Solution

1. **`TaskService`**: add `_taskMutationQueue` and route mutations through `_runExclusiveTaskOperation`, using internal `_loadTasks()` for read-modify-write paths.
2. **`StorageManager`**: retry JSON parsing up to 5 times with short backoff on transient parse errors.

## Test plan

- [x] Enable shared tasks with a valid `.todo4vcode/shared-tasks.json`
- [x] Edit task title/description via inline edit and task modal
- [x] Confirm no invalid JSON toast and changes persist after reload
- [x] `npm run compile` passes locally